### PR TITLE
`@autoclass` improvements for pyfields

### DIFF
--- a/autoclass/autoclass_.py
+++ b/autoclass/autoclass_.py
@@ -205,7 +205,9 @@ def autoclass_decorate(cls,              # type: Type[T]
             raise ValueError("`autoeq` can not be set to `True` simultaneously with `autodict`. Please set "
                              "`autodict=False`.")
         # By default execute with the known list of fields, so equivalent of `only_known_fields=True`.
-        execute_autodict_on_class(cls, selected_names=selected_names)
+        # Exclude private fields by default to have a consistent behaviour with autodict
+        public_names = tuple(n for n in selected_names if not n.startswith('_'))
+        execute_autodict_on_class(cls, selected_names=public_names)
     else:
         if autorepr is AUTO or autorepr:
             # By default execute with the known list of fields, so equivalent of `only_known_fields=True`.

--- a/autoclass/tests/features/test_autoclass.py
+++ b/autoclass/tests/features/test_autoclass.py
@@ -102,6 +102,19 @@ def test_autoclass_slots():
     assert str(a) == "Bar(bar=2, foo1='th', foo2=0)"
 
 
+def test_autoclass_private():
+    from pyfields import autofields
+
+    @autoclass
+    @autofields
+    class Example(object):
+        _priv = None
+        pub = 0
+
+    o = Example()
+    assert o == dict(pub=0)
+
+
 def test_autoclass_pyfields():
     """tests that @autoclass works with pyfields"""
     from pyfields import field
@@ -138,3 +151,33 @@ def test_autoclass_pyfields():
     # autodict was really disabled
     with pytest.raises(AttributeError):
         f.items()
+
+
+def test_autoclass_autopyfields():
+    """tests that @autoclass works with pyfields in auto mode"""
+
+    @autoclass(autofields=True)
+    class Foo(object):
+        foo1 = None
+        foo2 = 0
+
+    f = Foo(foo2=1)
+    assert f == dict(foo1=None, foo2=1)
+
+
+def test_autoclass_autopyfields_inherited():
+    """tests that @autoclass works with pyfields in auto mode"""
+
+    from pyfields import autofields
+
+    @autofields(make_init=False)
+    class Bar(object):
+        foo1 = None
+        foo2 = 0
+
+    @autoclass(autofields=True)
+    class Foo(Bar):
+        pass
+
+    f = Foo(foo2=1)
+    assert f == dict(foo1=None, foo2=1)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.2.0 - autoclass enhancements
+
+ - `@autoclass` now provides an `autofields` argument to apply `pyfields.autofields` automatically before applying autoclass. Fixes [#38](https://github.com/smarie/python-autoclass/issues/38)
+ - `@autoclass` now removes private fields from the generated autodict representation by default. Fixes [#37](https://github.com/smarie/python-autoclass/issues/37)
+
 ### 2.1.5 - python 2 packaging improvements
 
  - setup improvements: set the universal wheel flag to 1, and cleaned up the setup.py. Fixes [#36](https://github.com/smarie/python-autoclass/issues/36)

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,7 +143,9 @@ House(name='my_house', nb_floors=200)
 >>> assert obj == {'name': 'my_house', 'nb_floors': 200}  # comparison with dicts
 ```
 
-Note: this works with python 2.7, and 3.5+. See [`pyfields` documentation ](https://smarie.github.io/python-pyfields/) for details.
+Also, `@autoclass` now provides the possibility to set `autofields=True` to apply `pyfields.autofields` automatically before applying autoclass.
+
+Note: all of this works with python 2.7, and 3.5+. See [`pyfields` documentation ](https://smarie.github.io/python-pyfields/) for details.
 
 ## 2. Type and Value validation
 

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+
+        # 'Framework :: Pytest'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION

 - `@autoclass` now removes private fields by default from the associated autodict. Fixes #37

 - `@autoclass` now provides an `autofields` argument to apply autofields before applying autoclass.
Fixes #38 
